### PR TITLE
Duplicate QTabBar::tab property in order to workaround tab title space issue, bnc#888589

### DIFF
--- a/SLE/wizard/installation.qss
+++ b/SLE/wizard/installation.qss
@@ -199,6 +199,10 @@ QTabWidget::pane {
 QTabBar
 {
   qproperty-drawBase: 0;
+
+  /* Duplicate QTabBar::tab property. Without this property the tab space
+     is calculated narrower and bold font display messed up. bnc#888589, QTBUG#8209 */
+  font-weight: bold;
 }
 QTabBar::tab {
   color: #bbb;


### PR DESCRIPTION
for reference: http://susepaste.org/5225837 and http://susepaste.org/27595236
