### PR TITLE
SLE theme: added styling for non-Wizard main window (bnc#925882)

### DIFF
--- a/SLE/wizard/installation.qss
+++ b/SLE/wizard/installation.qss
@@ -3,6 +3,7 @@ QMainWindow { background: #2d2d2d; }
 QFileDialog { background: #2d2d2d; }
 QDialog { background: #2d2d2d; }
 YQWizard { background: #2d2d2d; }
+YQMainWinDock { background: #2d2d2d; }
 
 #LogoHBox {
   border-image: url(header-background.png);
@@ -516,4 +517,4 @@ QComboBoxPrivateScroller
 {
   background-color: #2d2d2d;
   color: white;
-} 
+}

--- a/package/yast2-theme-SLE.changes
+++ b/package/yast2-theme-SLE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May  6 08:24:46 UTC 2015 - lslezak@suse.cz
+
+- installation.qss: added background styling also for non-Wizard
+  main window (used in low-res screens) (bnc#925882)
+- 3.1.33
+
+-------------------------------------------------------------------
 Fri Aug 29 13:30:36 UTC 2014 - coolo@suse.com
 
 - move the icons in git to simplify openSUSE setup, but move them

--- a/package/yast2-theme-SLE.spec
+++ b/package/yast2-theme-SLE.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme-SLE
-Version:        3.1.32
+Version:        3.1.33
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme
-Version:        3.1.32
+Version:        3.1.33
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Normal main window is used in low-res screen installation, it fixes this issue:

![firstboot - qt ui broken](https://cloud.githubusercontent.com/assets/907998/7490115/dc4e6d28-f3dd-11e4-9f43-becc81acce5e.png)

- 3.1.33