### PR TITLE
Use a bigger font for the main dialog title (bsc#930864)

### DIFF
--- a/SLE/wizard/style.qss
+++ b/SLE/wizard/style.qss
@@ -41,4 +41,7 @@
   margin: 0px;
 }
 
+#DialogHeadingTop {
+  font: 18pt;
+}
 

--- a/SLE/wizard/style.qss
+++ b/SLE/wizard/style.qss
@@ -33,15 +33,19 @@
 
 /* #DialogIcon { max-width: 0px; margin: 0px; } */
 
-#DialogHeading { 
-  font-size: 20px; 
+#DialogHeadingTop {
+  font-size: 16pt;
   padding: 12pt;
-  /* letter-spacing: .2em; */
   font-style: bold;
   margin: 0px;
 }
 
-#DialogHeadingTop {
-  font: 18pt;
+#DialogHeadingLeft {
+  font: 16pt;
+  margin-top: 100%;
+  margin-right: 20px;
+  qproperty-alignment:AlignRight;
+}
+
 }
 

--- a/SLE/wizard/style.qss
+++ b/SLE/wizard/style.qss
@@ -47,5 +47,3 @@
   qproperty-alignment:AlignRight;
 }
 
-}
-

--- a/package/yast2-theme-SLE.changes
+++ b/package/yast2-theme-SLE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 14 08:17:54 UTC 2015 - lslezak@suse.cz
+
+- use a bigger font for the main dialog title (bsc#930864)
+- 3.1.34
+
+-------------------------------------------------------------------
 Wed May  6 08:24:46 UTC 2015 - lslezak@suse.cz
 
 - installation.qss: added background styling also for non-Wizard

--- a/package/yast2-theme-SLE.spec
+++ b/package/yast2-theme-SLE.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme-SLE
-Version:        3.1.33
+Version:        3.1.34
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme
-Version:        3.1.33
+Version:        3.1.34
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- The main dialog title originally looked as an usual text, it should be emphasized by using a bigger font.


- 3.1.34

Fixes this:
![yast2-000](https://cloud.githubusercontent.com/assets/907998/7628448/b6f770aa-fa23-11e4-82ba-19c7e521e6c4.png)

to this:
![yast2-001](https://cloud.githubusercontent.com/assets/907998/7628451/bac86266-fa23-11e4-95a4-8b322c8440c6.png)

Looks much better IMHO...
