### PR TITLE
Fixed styling for the package manager filter view widgets (bsc#950283)

### DIFF
--- a/SLE/wizard/installation.qss
+++ b/SLE/wizard/installation.qss
@@ -1,7 +1,7 @@
 /* Richtext: installation_richtext.css */
 QMainWindow { background: #2d2d2d; }
 QFileDialog { background: #2d2d2d; }
-QDialog { background: #2d2d2d; }
+QWidget { background: #2d2d2d; }
 YQWizard { background: #2d2d2d; }
 
 #LogoHBox {

--- a/SLE/wizard/installation.qss
+++ b/SLE/wizard/installation.qss
@@ -1,7 +1,7 @@
 /* Richtext: installation_richtext.css */
 QMainWindow { background: #2d2d2d; }
 QFileDialog { background: #2d2d2d; }
-QWidget { background: #2d2d2d; }
+QWidget { background: #2d2d2d; color #eee; }
 YQWizard { background: #2d2d2d; }
 
 #LogoHBox {

--- a/package/yast2-theme-SLE.changes
+++ b/package/yast2-theme-SLE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 20 10:56:16 UTC 2015 - lslezak@suse.cz
+
+- Fixed styling for the package manager filter view widgets
+  (unreadable white-on-white labels) (bsc#950283)
+- 3.1.31.1
+
+-------------------------------------------------------------------
 Fri Aug 29 13:30:36 UTC 2014 - coolo@suse.com
 
 - move the icons in git to simplify openSUSE setup, but move them

--- a/package/yast2-theme-SLE.spec
+++ b/package/yast2-theme-SLE.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme-SLE
-Version:        3.1.31
+Version:        3.1.31.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme
-Version:        3.1.31
+Version:        3.1.31.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Fixed unreadable white-on-white labels.
- 3.1.31.1

Notes:
=====

- It seems to be introduced by this change: https://github.com/libyui/libyui-qt-pkg/pull/28
- I tried fixing the styling just for `QScrollArea` widgets but it did not work so I changed the generic setting for all widgets via `QWidget`. The advantage is that it should apply to any widgets added/changed later so a similar bug should not happen in the future.
- Tested in a patched RC2 installation, see the screenshots below. I also checked whole installation workflow to check for possible regressions and everything was fine.

The Original Look
------------------------

![yast-sw-singe-search](https://cloud.githubusercontent.com/assets/907998/10606039/5022bd28-7730-11e5-9444-1e823930bd67.png)

![yast-sw-singe-inst-summary](https://cloud.githubusercontent.com/assets/907998/10606029/397265a6-7730-11e5-9d5e-459cacab4925.png)

With the Fix Applied
------------------------

![fixed_styling_search](https://cloud.githubusercontent.com/assets/907998/10606010/042dc2f0-7730-11e5-9056-8b59087911d2.png)
![fixed_styling_summary](https://cloud.githubusercontent.com/assets/907998/10606023/2262ac36-7730-11e5-8578-726f85314f4f.png)