### PR TITLE
Fixed styling for the package manager filter view widgets (bsc#950283)

### DIFF
--- a/SLE/wizard/installation.qss
+++ b/SLE/wizard/installation.qss
@@ -1,7 +1,7 @@
 /* Richtext: installation_richtext.css */
 QMainWindow { background: #2d2d2d; }
 QFileDialog { background: #2d2d2d; }
-QDialog { background: #2d2d2d; }
+QWidget { background: #2d2d2d; color #eee; }
 YQWizard { background: #2d2d2d; }
 YQMainWinDock { background: #2d2d2d; }
 

--- a/package/yast2-theme-SLE.changes
+++ b/package/yast2-theme-SLE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 20 10:56:16 UTC 2015 - lslezak@suse.cz
+
+- Fixed styling for the package manager filter view widgets
+  (unreadable white-on-white labels) (bsc#950283)
+- 3.1.35
+
+-------------------------------------------------------------------
 Fri Sep 11 08:17:54 UTC 2015 - simon@simotek.net
 
 - apps/pattern-e17.png -> apps/pattern-enlightenment.png due to 

--- a/package/yast2-theme-SLE.spec
+++ b/package/yast2-theme-SLE.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme-SLE
-Version:        3.1.34
+Version:        3.1.35
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme
-Version:        3.1.34
+Version:        3.1.35
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
(unreadable white-on-white labels)
- 3.1.35

Note
====

It was already reviewed in #59, but it turned out that the `SLE-12-SP1` branch was wrong (behind master) and the package was still submitted from `master`.