### PR TITLE
Hide the window title during installation (bsc#965086)

### DIFF
--- a/SLE/wmconfig/preferences.yast2
+++ b/SLE/wmconfig/preferences.yast2
@@ -17,8 +17,14 @@ KeySysSwitchLast="Alt+Shift+Tab"
 Win95Keys=0
 
 # Colors
+# HACK: "hide" the title during installation by setting the same foreground
+# and background colors (see https://bugzilla.suse.com/show_bug.cgi?id=965086)
 ColorActiveTitleBar="rgb:28/ae/73"
+ColorActiveTitleBarText="rgb:28/ae/73"
+# HACK: "hide" the title during installation by setting the same foreground
+# and background colors (see https://bugzilla.suse.com/show_bug.cgi?id=965086)
 ColorNormalTitleBar="rgb:65/65/65"
+ColorNormalTitleBarText="rgb:65/65/65"
 ColorActiveBorder="rgb:2d/2d/2d"
 ColorNormalBorder="rgb:2d/2d/2d"
 

--- a/package/yast2-theme-SLE.changes
+++ b/package/yast2-theme-SLE.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 25 13:55:27 UTC 2016 - lslezak@suse.cz
+
+- Hide the window title during installation (workaround: set the
+  same foreground and background colors) (bsc#965086)
+- 3.1.38
+
+-------------------------------------------------------------------
 Wed Feb 10 13:12:22 UTC 2016 - cwh@suse.com
 
 - Fix spelling of SUSE Linux. (bsc#964241)

--- a/package/yast2-theme-SLE.spec
+++ b/package/yast2-theme-SLE.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme-SLE
-Version:        3.1.37
+Version:        3.1.38
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme
-Version:        3.1.37
+Version:        3.1.38
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
This is a fix for https://bugzilla.suse.com/show_bug.cgi?id=965086.

:exclamation: **Trick: Set the same foreground and background colors.** :boom: 

In SP2 staging (after *icewm* package update to 1.3.12) the window title during installation is set to "YaST2". In SLE12-GM and SLE12-SP1 it was empty.

But in installed system we want to have a title to properly show the name in the task bar or the window switcher.

Unfortunately the window title cannot be changed from YaST, it's [hardcoded in libyui-qt](https://github.com/libyui/libyui-qt/blob/647d77ad4c94e50b01ab8ed69ce68a712725f762/src/YQUI.cc#L192). If we would like to make it configurable we would have to introduce a new API and fix at least two packages (*libyui-qt* and *yast2-installation*).

With this simple trick we just need to add two more lines into the icewm config used during installation. (In the running system icewm uses it's original default config.)


## Screenshots

### Original Look
![sp2_with_title](https://cloud.githubusercontent.com/assets/907998/13322495/f536d6b0-dbd4-11e5-9d3e-342e7df2d0d9.png)

### With the Fix
![sp2_hide_title](https://cloud.githubusercontent.com/assets/907998/13322504/03aae4b6-dbd5-11e5-9350-da5884818fb8.png)
