### PR TITLE
Fix group title

### DIFF
--- a/SLE/wizard/style.qss
+++ b/SLE/wizard/style.qss
@@ -47,3 +47,15 @@
   qproperty-alignment:AlignRight;
 }
 
+QGroupBox {
+  border: 0px;
+  margin-top: 2.5ex;
+  margin-left: 10px;
+  margin-right: 2px;
+}
+
+QGroupBox::title {
+  subcontrol-origin: margin;
+  subcontrol-position: left top;
+  font-weight: bold;
+}

--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct 14 08:57:21 UTC 2016 - jreidinger@suse.com
+
+- fix button group title padding on SLE (bsc#877477)
+- 3.2.0
+
+-------------------------------------------------------------------
 Tue Oct  4 13:38:27 UTC 2016 - jreidinger@suse.com
 
 - unify back -SLE subpackage to main yast2-theme. This is done by

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-theme
-Version:        3.1.42
+Version:        3.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
before:
![old_theme](https://cloud.githubusercontent.com/assets/478871/19381712/41de73c2-91fd-11e6-9387-06910bf9d900.png)
after:
![style_after_fix](https://cloud.githubusercontent.com/assets/478871/19381719/46cb22c2-91fd-11e6-96c9-f11b39c88c48.png)

I know now text is not so bold, but at least it is consistent with opensuse style ( and I do not like too bold text which is there before )