### PR TITLE
Fixed black-on-black color for the editable combo box (bsc#1052723)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.yardoc/
+doc/
 Makefile
 /Makefile.am
 Makefile.in

--- a/SLE/wizard/cyan-black.qss
+++ b/SLE/wizard/cyan-black.qss
@@ -264,7 +264,7 @@ QComboBox::disabled {
 QComboBox:focus {
   background-color: cyan;
   border: 1px solid cyan;
-  color: black;
+  color: cyan;
 }
 /* QComboBox gets the "on" state when the popup is open */
 QComboBox:!editable:on, QComboBox::drop-down:editable:on {

--- a/SLE/wizard/white-black.qss
+++ b/SLE/wizard/white-black.qss
@@ -264,7 +264,7 @@ QComboBox::disabled {
 QComboBox:focus {
   background-color: white;
   border: 1px solid white;
-  color: black;
+  color: white;
 }
 /* QComboBox gets the "on" state when the popup is open */
 QComboBox:!editable:on, QComboBox::drop-down:editable:on {

--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 11 11:48:06 UTC 2017 - lslezak@suse.cz
+
+- Fixed black-on-black color for the editable combo box in the
+  cyan and b&w color themes (bsc#1052723)
+- 3.2.4
+
+-------------------------------------------------------------------
 Tue Jun 13 12:27:49 UTC 2017 - lnussel@suse.de
 
 - Remove red "N" from logos (boo#953761)

--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -3,7 +3,7 @@ Fri Aug 11 11:48:06 UTC 2017 - lslezak@suse.cz
 
 - Fixed black-on-black color for the editable combo box in the
   cyan and b&w color themes (bsc#1052723)
-- 3.2.4
+- 3.3.0
 
 -------------------------------------------------------------------
 Tue Jun 13 12:27:49 UTC 2017 - lnussel@suse.de

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -19,7 +19,7 @@
 
 
 Name:           yast2-theme
-Version:        3.2.3
+Version:        3.2.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -19,7 +19,7 @@
 
 
 Name:           yast2-theme
-Version:        3.2.4
+Version:        3.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
...in the cyan and b&w color themes

- 3.2.4

## Note

The tricky part is that the `background-color` attribute defined few lines above refers to the combobox "border" around, not the editable text area inside (see the screenshots). So having the same `background-color` and `color` might look wrong at the first sight...

The same problem was in the black and white theme, the high contrast theme is OK.

## Screenshots

### The Original Look
![ntp-cyan-broken](https://user-images.githubusercontent.com/907998/29212196-7f08ba4a-7e9d-11e7-9cea-d9cc83c3bfbc.png)

### After Applying the Fix
![ntp-cyan-fixed](https://user-images.githubusercontent.com/907998/29212205-8854a208-7e9d-11e7-9197-7c8bab598415.png)




