### PR TITLE
Fixed the check box style in the MultiSelectionBox widget (bsc#1062356)

### DIFF
--- a/SLE/wizard/installation.qss
+++ b/SLE/wizard/installation.qss
@@ -152,18 +152,22 @@ QCheckBox, YQCheckBoxFrame::indicator { min-height: 24px; color: #eee; margin-to
 QCheckBox::disabled { color: gray; }
 
 YQCheckBoxFrame::indicator:checked,
+QTreeView::indicator:checked,
 QCheckBox::indicator:checked:enabled {
   image: url(inst_checkbox-on.png);
 }
 YQCheckBoxFrame::indicator:unchecked,
+QTreeView::indicator:unchecked,
 QCheckBox::indicator:unchecked:enabled {
   image: url(inst_checkbox-off.png);
 }
-
-QCheckBox::indicator:checked:disabled {
+YQCheckBoxFrame::indicator:checked:disabled,
+QCheckBox::indicator:checked:disabled,
+QTreeView::indicator:checked:disabled {
   image: url(inst_checkbox-on-disabled.png);
 }
 YQCheckBoxFrame::indicator:unchecked:disabled,
+QTreeView::indicator:unchecked:disabled,
 QCheckBox::indicator:unchecked {
   image: url(inst_checkbox-off-disabled.png);
 }
@@ -183,6 +187,10 @@ QRadioButton::indicator:unchecked:disabled {
 }
 QRadioButton::indicator:checked:disabled {
    image: url(inst_radio-button-checked-disabled.png);
+}
+
+YQMultiSelectionBox QTreeView::item {
+  margin: 5px 0;
 }
 
 YQMultiLineEdit QTextEdit { color: #fff; }

--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Oct 12 15:33:48 UTC 2017 - lslezak@suse.cz
+
+- Fixed the check box style in the MultiSelectionBox widget
+  to use the same icons as the usual CheckBox widgets, the check
+  boxes were almost invisible (bsc#1062356)
+- 4.0.3
+
+-------------------------------------------------------------------
 Fri Oct  6 15:08:20 UTC 2017 - jreidinger@suse.com
 
 - improve auto-selected.png and add also svg source for it

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -19,7 +19,7 @@
 
 
 Name:           yast2-theme
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Fixed the `MultiSelectionBox` widget style to use the same icons as the usual `CheckBox` widgets.

See [bsc#1062356#c5](https://bugzilla.suse.com/show_bug.cgi?id=1062356#c5) for more details.

## The Original Look

#### Nothing Selected

The check boxes were almost invisible, the problem is that clicking the label does not change the check box state. It looked like you can select only one item in the list and that the first item is selected:

![multisel_orig_empty](https://user-images.githubusercontent.com/907998/31505108-63157578-af74-11e7-8d85-dcc1b6e2c9cd.png)

That's wrong, nothing is selected. After pressing `Next` you could be surprised that no addon was added...

#### An Addon Selected

After selecting an item it's more visible that there are check boxes, but they looked differently than the standard check boxes used in the other dialogs. That could be quite confusing:

![multisel_orig_selected](https://user-images.githubusercontent.com/907998/31505436-26fb2cf8-af75-11e7-8951-dd94e0576eb4.png)

## The Fix

#### Nothing Selected

After styling the check boxes to use the same icon as the standard check boxes you can easily see that nothing is selected:

![multisel_fixed_empty](https://user-images.githubusercontent.com/907998/31505092-5895b4be-af74-11e7-87cf-96035c39f56e.png)

#### An Addon Selected

After selecting addons you will see the standard check boxes, just like in the other dialogs:

![multisel_fixed_selected](https://user-images.githubusercontent.com/907998/31505703-c4bba850-af75-11e7-8fa8-b548a0c719d1.png)


