### PR TITLE
Don't hard-code the role text color

### DIFF
--- a/SLE/wizard/cyan-black_richtext.css
+++ b/SLE/wizard/cyan-black_richtext.css
@@ -1,4 +1,5 @@
 a { color: cyan; }
+a.dontlooklikealink { color: cyan; text-decoration: none; }
 .red { color: #ff0000; }
 .blue { color: cyan; }
 .green { color: cyan; }

--- a/SLE/wizard/highcontrast_richtext.css
+++ b/SLE/wizard/highcontrast_richtext.css
@@ -1,4 +1,5 @@
 a { color: #ffff00; }
+a.dontlooklikealink { color: cyan; text-decoration: none; }
 .red { color: #ff0000; }
 .blue { color: cyan; }
 .green { color: #ffff00; }

--- a/SLE/wizard/installation_richtext.css
+++ b/SLE/wizard/installation_richtext.css
@@ -1,4 +1,5 @@
 a { color: #28ae73; }
+a.dontlooklikealink { color: white; text-decoration: none; }
 .red { color: #FF3C3C; }
 .blue { color: cyan; }
 .green { color: #28ae73; }

--- a/SLE/wizard/white-black_richtext.css
+++ b/SLE/wizard/white-black_richtext.css
@@ -1,4 +1,5 @@
 a { color: white; }
+a.dontlooklikealink { color: white; text-decoration: none; }
 .red { color: #ff0000; }
 .blue { color: white; }
 .green { color: white; }

--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 16 12:58:49 UTC 2018 - mvidner@suse.com
+
+- Don't hard-code the role text color (bsc#1087399).
+- 4.0.4
+
+-------------------------------------------------------------------
 Thu Oct 12 15:33:48 UTC 2017 - lslezak@suse.cz
 
 - Fixed the check box style in the MultiSelectionBox widget

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -19,7 +19,7 @@
 
 
 Name:           yast2-theme
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- [bsc#1087399](https://bugzilla.suse.com/show_bug.cgi?id=1087399)
- https://trello.com/c/VasiMQRM/1401-2-bug-1087399-sle-hardcodes-text-color-making-kubic-white-on-white