### PR TITLE
WIP: Fix YaST Firstboot Branding for openSUSE Distros

### DIFF
--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 18 15:10:21 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Require yast2-qt-branding-openSUSE for openSUSE distros
+  so YaST firstboot has some branding (bsc#1105792)
+- 4.1.11
+
+-------------------------------------------------------------------
 Fri Feb 15 08:17:36 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Update oxygen icon theme (boo#1125450)

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-theme
-Version:        4.1.10
+Version:        4.1.11
 Release:        0
 
 Source0:        %{name}-%{version}.tar.bz2
@@ -34,6 +34,11 @@ BuildRequires:  breeze5-icons
 %endif
 
 Requires:       hicolor-icon-theme
+
+%if 0%{?is_opensuse}
+# bsc#1105792: firstboot wizard missing branding
+Requires:       yast2-qt-branding-openSUSE
+%endif
 
 Provides:       yast2-branding = %{version}
 Provides:       yast2_theme = %{version}


### PR DESCRIPTION
## Trello

https://trello.com/c/oInRyZ4W/

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1105792

## Problem

No branding in openSUSE distros for the YaST firstboot wizard:

![yast-firstboot-openSUSE](https://user-images.githubusercontent.com/11538225/54541029-5700b980-4999-11e9-85fa-c5603e2b0df6.png)

It works in SLES, though:

![yast-firstboot-SLES](https://user-images.githubusercontent.com/11538225/54541044-5e27c780-4999-11e9-927b-ba0c9cf100f2.png)


## Cause

No Qt style sheet installed.

For SLES, this is part of the _yast-theme_ package:

https://github.com/yast/yast-theme/blob/master/theme/SLE/wizard/style.qss

For openSUSE, this comes with the _yast-qt-branding-openSUSE_ package which is a subpackage of the _openSUSE-branding_ source repo:

https://github.com/openSUSE/branding/blob/leap-15.1/yast/style.qss

https://build.opensuse.org/package/view_file/openSUSE:Leap:15.1/branding-openSUSE/branding-openSUSE.spec?expand=1
(line 327)

## Fix

Added a `Requires` for that _yast-qt-branding-openSUSE_ package to _yast-theme_ for openSUSE distros.

## Test

Manual test:

- Install latest Leap 15.1 ISO into a VM
- After the installation is done, install the package for firstboot (this is not on the installation medium, only in online repos):

```
    zypper in yast2-firstboot
```

- Copy those updated theme packages to that newly installed system:
```
    scp "somehost:/tmp/yast2-theme*.rpm" /tmp
```

- Try to update this theme package (Notice it now requires yast2-qt-branding-openSUSE):
```
    rpm -Uhv /tmp/yast2-theme*.rpm
```
(this will fail because yast2-qt-branding-openSUSE is not installed yet)

- Install yast2-qt-branding-openSUSE and try the same again:

```
    zypper in yast2-qt-branding-openSUSE
    rpm -Uhv /tmp/yast2-theme*.rpm
```

- Touch the _firstboot_ file and reboot
  https://en.opensuse.org/YaST_Firstboot

```
    touch /var/lib/YaST2/reconfig_system
    reboot
```

- The _firstboot_ wizard should now start. Check if there is branding now, i.e. no more all flat grey areas, with the SUSE chamaeleon logon on the top left and colored wizard steps on the left side.

## Screenshot

![yast-firstboot-openSUSE-fixed](https://user-images.githubusercontent.com/11538225/54674169-24230680-4afc-11e9-82ce-ac9a8986b01a.png)

## Does this Drag in Qt/X11 Now?

No, it doesn't.

I installed the pure text based server role, then did the same as above, and it did not attempt to install anything Qt or X related - see screenshots below.

![shell-session-01](https://user-images.githubusercontent.com/11538225/54676678-7c103c00-4b01-11e9-9fb8-3bcb3f476cea.png)

![shell-session-02](https://user-images.githubusercontent.com/11538225/54676685-80d4f000-4b01-11e9-8aba-e09d1e0da609.png)
