### PR TITLE
Use *qt-branding instead of *qt-branding-openSUSE

### DIFF
--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -28,7 +28,7 @@ BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools
 BuildRequires:  rubygem(yast-rake)
 %if 0%{?is_opensuse}
-BuildRequires:  yast2-qt-branding-openSUSE
+BuildRequires:  yast2-qt-branding
 BuildRequires:  oxygen5-icon-theme
 BuildRequires:  breeze5-icons
 %endif
@@ -37,7 +37,7 @@ Requires:       hicolor-icon-theme
 
 %if 0%{?is_opensuse}
 # bsc#1105792: firstboot wizard missing branding
-Requires:       yast2-qt-branding-openSUSE
+Requires:       yast2-qt-branding
 %endif
 
 Provides:       yast2-branding = %{version}


### PR DESCRIPTION
Change dependency to a bit more universal yast2-qt-branding (instead of yast2-qt-branding-openSUSE).
For typical openSUSE users, yast2-qt-branding-openSUSE will be used anyway.
(https://bugzilla.suse.com/show_bug.cgi?id=1105792#c25)