### PR TITLE
Don't leave dead symlinks behind on SLE

### DIFF
--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -119,9 +119,10 @@ cp theme/openSUSE/wmconfig/* %{buildroot}/etc/icewm/
 %else
 mv %{buildroot}%{yast_themedir}/SLE %{buildroot}%{yast_themedir}/current
 cp theme/SLE/wmconfig/* %{buildroot}/etc/icewm/
-# SLE doesn't have oxygen5-icon-theme
-rm -rf %{buildroot}%{yast_icondir}/oxygen %{buildroot}%{yast_icondir}/breeze
-rm -rf %{buildroot}%{yast_icondir}/oxygen %{buildroot}%{yast_icondir}/breeze-dark
+# SLE doesn't have those icon themes:
+rm -rf %{buildroot}%{yast_icondir}/oxygen
+rm -rf %{buildroot}%{yast_icondir}/breeze
+rm -rf %{buildroot}%{yast_icondir}/breeze-dark
 %endif
 
 # We only need current theme

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -121,6 +121,7 @@ mv %{buildroot}%{yast_themedir}/SLE %{buildroot}%{yast_themedir}/current
 cp theme/SLE/wmconfig/* %{buildroot}/etc/icewm/
 # SLE doesn't have oxygen5-icon-theme
 rm -rf %{buildroot}%{yast_icondir}/oxygen %{buildroot}%{yast_icondir}/breeze
+rm -rf %{buildroot}%{yast_icondir}/oxygen %{buildroot}%{yast_icondir}/breeze-dark
 %endif
 
 # We only need current theme


### PR DESCRIPTION
# Problem

yast2-theme fails to build an RPM:

```
[   59s] calling /usr/lib/rpm/brp-suse.d/brp-25-symlink
[   59s] ERROR: link target doesn't exist (neither in build root nor in installed system):
[   59s]   /usr/share/icons/breeze-dark/apps/32/pattern-apparmor.svg -> /usr/share/icons/breeze-dark/preferences/32/preferences-security-apparmor.svg
[   59s] Add the package providing the target to BuildRequires and Requires
[   59s] ERROR: link target doesn't exist (neither in build root nor in installed system):
[   59s]   /usr/share/icons/breeze-dark/apps/32/pattern-cli.svg -> /usr/share/icons/breeze-dark/apps/32/utilities-terminal.svg
...
...
```

# Fix

Remove the (intentionally created) dead symlinks in the %install phase for non-openSUSE products

# Background

https://github.com/yast/yast-theme/pull/105
https://bugzilla.suse.com/show_bug.cgi?id=1108422