### PR TITLE
Update desktop file build requirement

### DIFF
--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 09:19:14 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.4
+
+-------------------------------------------------------------------
 Sun Jul 14 18:55:53 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add missing Oxygen icons (boo#1125450)

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-theme
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 
 Source0:        %{name}-%{version}.tar.bz2

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -31,6 +31,7 @@ BuildRequires:  rubygem(yast-rake)
 BuildRequires:  yast2-qt-branding
 BuildRequires:  oxygen5-icon-theme
 BuildRequires:  breeze5-icons
+BuildRequires:  update-desktop-files
 %endif
 
 Requires:       hicolor-icon-theme


### PR DESCRIPTION
> - The recent fix in YaST RPM macros now updates the desktop files
> - The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
> - Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`

---

Originally fixed by @lslezak in https://github.com/yast/yast-instserver/pull/45