### PR TITLE
Uses a transparent background for YAST_BANNER

### DIFF
--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 19 10:55:36 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Uses a transparent background for the YAST_BANNER
+  (jsc#SLE-9424, bsc#1162997)
+- 4.2.9
+
+-------------------------------------------------------------------
 Wed Dec  4 16:36:18 CET 2019 - schubi@suse.de
 
 - Added a banner on the upper/right side of the YaST layout.

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-theme
-Version:        4.2.8
+Version:        4.2.9
 Release:        0
 
 Source0:        %{name}-%{version}.tar.bz2

--- a/theme/SLE/wizard/cyan-black.qss
+++ b/theme/SLE/wizard/cyan-black.qss
@@ -17,7 +17,7 @@ YQWizard { background: black; }
 }
 
 #DialogBanner {
-  background-color: #000;
+  background-color: transparent;
   font-family: Raleway, Sans-serif;
   font: 24pt;
   margin-right: 20px;

--- a/theme/SLE/wizard/cyan-black.qss
+++ b/theme/SLE/wizard/cyan-black.qss
@@ -104,7 +104,7 @@ YQPakageSelector {
   border: 1px inset cyan;
   selection-background-color: cyan;
   selection-color: black;
-  border-radius: 4px; 
+  border-radius: 4px;
 }
 
 YQGenericDetailsView,
@@ -510,7 +510,7 @@ QSplitter::handle {
 #RepoUpgradeLabel {
   color: black;
   background: #35b9ab;
-} 
+}
 
 YQPkgVersionsView QWidget { background: black; }
 
@@ -540,7 +540,7 @@ QComboBoxPrivateScroller
   color: cyan;
 }
 
-#steps 
+#steps
 {
   font-size: 90%;
   border: 1px solid;
@@ -569,7 +569,7 @@ QComboBoxPrivateScroller
 }
 
 .steps_heading {
-   font-weight: bold;  
+   font-weight: bold;
    color: cyan;
    margin-bottom: 7px;
 }

--- a/theme/SLE/wizard/highcontrast.qss
+++ b/theme/SLE/wizard/highcontrast.qss
@@ -18,7 +18,7 @@ YQMainWinDock { background: black; }
 }
 
 #DialogBanner {
-  background-color: #000;
+  background-color: transparent;
   font-family: Raleway, Sans-serif;
   font: 24pt;
   margin-right: 20px;

--- a/theme/SLE/wizard/highcontrast.qss
+++ b/theme/SLE/wizard/highcontrast.qss
@@ -105,7 +105,7 @@ YQPakageSelector {
   border: 1px inset white;
   selection-background-color: #ffff00;
   selection-color: black;
-  border-radius: 4px; 
+  border-radius: 4px;
 }
 
 YQGenericDetailsView,
@@ -239,7 +239,7 @@ QTabBar::tab {
 QTabBar::tab:selected {
   color: white;
   background: #2d2d2d;
-  border: 1px solid white; 
+  border: 1px solid white;
   border-bottom: none;
 }
 
@@ -512,7 +512,7 @@ QSplitter::handle {
 #RepoUpgradeLabel {
   color: cyan;
   background: black;
-} 
+}
 
 YQPkgVersionsView QWidget { background: #2d2d2d; }
 
@@ -542,7 +542,7 @@ QComboBoxPrivateScroller
   color: white;
 }
 
-#steps 
+#steps
 {
   font-size: 90%;
   border: 1px solid;
@@ -571,7 +571,7 @@ QComboBoxPrivateScroller
 }
 
 .steps_heading {
-   font-weight: bold;  
+   font-weight: bold;
    color: white;
    margin-bottom: 7px;
 }

--- a/theme/SLE/wizard/installation.qss
+++ b/theme/SLE/wizard/installation.qss
@@ -78,7 +78,7 @@ QTreeView, QTreeWidget {
   background-color: #071B2A;
   border: 1px inset #566B79;
   alternate-background-color: #00C081;
-  selection-background-color: #03101C; 
+  selection-background-color: #03101C;
   selection-color: #00C081;
   border-radius: 4px;
 }
@@ -88,7 +88,7 @@ QTableView {
   color: #EDEFF0;
   background-color: #071B2A;
   border: 1px inset #566B79;
-  selection-background-color: #00C081; 
+  selection-background-color: #00C081;
   selection-color: #0D2C40;
   border-radius: 4px;
 }

--- a/theme/SLE/wizard/installation.qss
+++ b/theme/SLE/wizard/installation.qss
@@ -18,7 +18,7 @@ YQMainWinDock { background: #0D2C40; }
 }
 
 #DialogBanner {
-  background-color: #000;
+  background-color: transparent;
   font-family: Raleway, Sans-serif;
   font: 24pt;
   margin-right: 20px;

--- a/theme/SLE/wizard/white-black.qss
+++ b/theme/SLE/wizard/white-black.qss
@@ -17,7 +17,7 @@ YQWizard { background: black; }
 }
 
 #DialogBanner {
-  background-color: #000;
+  background-color: transparent;
   font-family: Raleway, Sans-serif;
   font: 24pt;
   margin-right: 20px;

--- a/theme/SLE/wizard/white-black.qss
+++ b/theme/SLE/wizard/white-black.qss
@@ -104,7 +104,7 @@ YQPakageSelector {
   border: 1px inset white;
   selection-background-color: white;
   selection-color: black;
-  border-radius: 4px; 
+  border-radius: 4px;
 }
 
 YQGenericDetailsView,
@@ -510,7 +510,7 @@ QSplitter::handle {
 #RepoUpgradeLabel {
   color: black;
   background: #35b9ab;
-} 
+}
 
 YQPkgVersionsView QWidget { background: black; }
 
@@ -540,7 +540,7 @@ QComboBoxPrivateScroller
   color: white;
 }
 
-#steps 
+#steps
 {
   font-size: 90%;
   border: 1px solid;
@@ -569,7 +569,7 @@ QComboBoxPrivateScroller
 }
 
 .steps_heading {
-   font-weight: bold;  
+   font-weight: bold;
    color: white;
    margin-bottom: 7px;
 }


### PR DESCRIPTION
## Problem

The black background of [recently added upper/right banner](https://github.com/yast/yast-theme/pull/125) generates a (hard to notice) [black stripe in the installer's header](https://bugzilla.suse.com/show_bug.cgi?id=1162997).

## Solution

To use a _transparent_ background instead.

## Screenshots

<details>
<summary>Click to show/hide</summary>

---


#### Before


![68424950](https://user-images.githubusercontent.com/1691872/77061275-e4725180-69d1-11ea-9ea6-85d2c70617eb.png)

#### After

![after](https://user-images.githubusercontent.com/1691872/77062466-d58c9e80-69d3-11ea-91bd-b52c2e074c39.png)



</details>