### PR TITLE
Add font dependency

### DIFF
--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 10 15:31:08 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Add raleway fonts dependency (related to bsc#1158298).
+- 4.2.10
+
+-------------------------------------------------------------------
 Thu Mar 19 10:55:36 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Uses a transparent background for the YAST_BANNER

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-theme
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 
 Source0:        %{name}-%{version}.tar.bz2

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -39,6 +39,7 @@ Requires:       hicolor-icon-theme
 %if 0%{?is_opensuse}
 # bsc#1105792: firstboot wizard missing branding
 Requires:       yast2-qt-branding
+Requires:       raleway-fonts
 %else
 # on SLE the qt branding files are included in yast2-them so they
 # conflict with the separate package that exists on openSUSE


### PR DESCRIPTION
## Problem

The style-sheet provided for the installation (*installation.qss*) uses the *Raleway* font family. Such fonts are not installed in the target system, making the *first-boot* module to look slightly different to the installer (a different font is used for the title of the dialogs). 

* https://bugzilla.suse.com/show_bug.cgi?id=1158298

* https://trello.com/c/u0EkkjpE/1954-5-unify-firstboot-look-and-feel-with-installer

## Solution

The *raleway-fonts* package is added as dependency to ensure such fonts will be installed in the target system.
