### PR TITLE
Add pattern-cinnamon icon

### DIFF
--- a/icons/hicolor/scalable/apps/pattern-cinnamon.svg
+++ b/icons/hicolor/scalable/apps/pattern-cinnamon.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+<metadata>
+<rdf:RDF>
+<cc:Work rdf:about="">
+<dc:format>image/svg+xml</dc:format>
+<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+<dc:title/>
+</cc:Work>
+</rdf:RDF>
+</metadata>
+<defs>
+<linearGradient id="a" x1="8.4461" x2="28.259" y1="6.2689" y2="28.359" gradientUnits="userSpaceOnUse">
+<stop stop-opacity=".2088" offset="0"/>
+<stop stop-opacity="0" offset="1"/>
+</linearGradient>
+<linearGradient id="b" x1="30" x2=".14963" y1="30" y2=".069732" gradientUnits="userSpaceOnUse">
+<stop stop-color="#da6125" offset="0"/>
+<stop stop-color="#e17d4a" offset="1"/>
+</linearGradient>
+</defs>
+<rect x="2" y="2" width="28" height="28" rx="4" fill="url(#b)"/>
+<path d="m2.0139 25v1c0 2.216 1.784 4 4 4h20c2.216 0 4-1.784 4-4v-1c0 2.216-1.784 4-4 4h-20c-2.216 0-4-1.784-4-4z" fill="#292c2f" opacity=".2"/>
+<path d="m22.554 9.003s-6.6418-3.9013-12.273-0.266c-5.6315 3.6353-1.3564 14.257-1.3564 14.257l7.0357 7.0062c5.1802 0.04871 9.1509-0.02585 9.1509-0.02585 2.2335-0.16301 4.6437-0.43564 4.8896-4.6365l-1e-6 -8.9195z" fill="url(#a)"/>
+<path d="m15.745 6.2358c-5.3924 0-9.7642 4.3718-9.7642 9.7642 0 5.3932 4.3718 9.7642 9.7642 9.7642 5.3932 0 9.7642-4.3709 9.7642-9.7642 0-5.3924-4.3709-9.7642-9.7642-9.7642zm0 1.6649c4.4737 0 8.0992 3.6255 8.0992 8.0992 0 0.68807-0.09387 1.3521-0.25538 1.99l-3.8523-4.2818-4.9252 5.6034 2.3764-4.7544-1.1874-2.1226-7.0014 8.0461c-0.85414-1.2835-1.3532-2.8237-1.3532-4.4808 0-4.4737 3.6255-8.0992 8.0992-8.0992z" fill="#fff" stroke-width=".84906"/>
+</svg>

--- a/icons/hicolor/scalable/apps/pattern-cinnamon.svg
+++ b/icons/hicolor/scalable/apps/pattern-cinnamon.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 <metadata>
 <rdf:RDF>
 <cc:Work rdf:about="">
@@ -10,17 +10,22 @@
 </rdf:RDF>
 </metadata>
 <defs>
-<linearGradient id="a" x1="8.4461" x2="28.259" y1="6.2689" y2="28.359" gradientUnits="userSpaceOnUse">
+<linearGradient id="e" x1="8.4461" x2="24.603" y1="6.2689" y2="24.571" gradientUnits="userSpaceOnUse">
 <stop stop-opacity=".2088" offset="0"/>
 <stop stop-opacity="0" offset="1"/>
 </linearGradient>
-<linearGradient id="b" x1="30" x2=".14963" y1="30" y2=".069732" gradientUnits="userSpaceOnUse">
+<linearGradient id="c" x1="30" x2=".14963" y1="30" y2=".069732" gradientUnits="userSpaceOnUse">
 <stop stop-color="#da6125" offset="0"/>
 <stop stop-color="#e17d4a" offset="1"/>
 </linearGradient>
+<linearGradient id="d" x1="7.8488" x2="14.108" y1="3.5121" y2="14.183" gradientUnits="userSpaceOnUse">
+<stop stop-opacity=".2088" offset="0"/>
+<stop stop-opacity="0" offset="1"/>
+</linearGradient>
 </defs>
-<rect x="2" y="2" width="28" height="28" rx="4" fill="url(#b)"/>
+<rect x="2" y="2" width="28" height="28" rx="4" fill="url(#c)"/>
 <path d="m2.0139 25v1c0 2.216 1.784 4 4 4h20c2.216 0 4-1.784 4-4v-1c0 2.216-1.784 4-4 4h-20c-2.216 0-4-1.784-4-4z" fill="#292c2f" opacity=".2"/>
-<path d="m22.554 9.003s-6.6418-3.9013-12.273-0.266c-5.6315 3.6353-1.3564 14.257-1.3564 14.257l7.0357 7.0062c5.1802 0.04871 9.1509-0.02585 9.1509-0.02585 2.2335-0.16301 4.6437-0.43564 4.8896-4.6365l-1e-6 -8.9195z" fill="url(#a)"/>
+<path d="m22.554 9.003s2.9064 9.7686 1.9845 10.503c-0.92196 0.73463-8.5381-7.0718-8.5381-7.0718l-7.0757 10.56 7.0357 7.0062c5.1802 0.04871 9.1509-0.02585 9.1509-0.02585 2.2335-0.16301 4.6437-0.43564 4.8896-4.6365l-1e-6 -8.9195z" fill="url(#e)"/>
+<path d="m22.554 9.003s-6.6418-3.9013-12.273-0.266c-5.6315 3.6353-1.3564 14.257-1.3564 14.257l6.9754 0.64193c13.304 1.1971 9.0471 3.5176 8.9592-6.4244z" fill="url(#d)"/>
 <path d="m15.745 6.2358c-5.3924 0-9.7642 4.3718-9.7642 9.7642 0 5.3932 4.3718 9.7642 9.7642 9.7642 5.3932 0 9.7642-4.3709 9.7642-9.7642 0-5.3924-4.3709-9.7642-9.7642-9.7642zm0 1.6649c4.4737 0 8.0992 3.6255 8.0992 8.0992 0 0.68807-0.09387 1.3521-0.25538 1.99l-3.8523-4.2818-4.9252 5.6034 2.3764-4.7544-1.1874-2.1226-7.0014 8.0461c-0.85414-1.2835-1.3532-2.8237-1.3532-4.4808 0-4.4737 3.6255-8.0992 8.0992-8.0992z" fill="#fff" stroke-width=".84906"/>
 </svg>

--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sun Feb  7 09:11:52 UTC 2021 - shenlebantongying <shenlebantongying@gmail.com>
+
+- Add icon for cinnamon pattern
+- 4.3.2
+
+-------------------------------------------------------------------
 Fri Jul 10 15:31:08 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Add raleway fonts dependency (related to bsc#1158298).

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-theme
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 
 Source0:        %{name}-%{version}.tar.bz2


### PR DESCRIPTION
`patterns-cinnamon` have recently been created, this is the icon for it :)

Here is a preview:
![versions2](https://user-images.githubusercontent.com/20123683/107160898-103e5300-6967-11eb-98ce-ae987aa15f80.png)

or preview the .svg file <https://raw.githubusercontent.com/shenlebantongying/yast-theme/master/icons/hicolor/scalable/apps/pattern-cinnamon.svg>

The design is based on other patterns, and numerically identical with other patterns as
 
![image](https://user-images.githubusercontent.com/20123683/107159895-e08c4c80-6960-11eb-8611-4a1390157772.png)

related links:
cinnamon homepage: <https://cinnamon-spices.linuxmint.com/>
obs: <https://build.opensuse.org/package/show/X11:Cinnamon:Factory/patterns-cinnamon>
bugzilla: <https://bugzilla.opensuse.org/show_bug.cgi?id=1181253>