### PR TITLE
Use Poppins fonts in all styles

### DIFF
--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 11 10:31:02 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Use Poppins fonts instead of Raleway in all style files.
+- Part of jsc#SLE-15714.
+- 4.3.4
+
+-------------------------------------------------------------------
 Wed Feb 10 15:33:06 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Update branding (jsc#SLE-15714).

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-theme
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 
 Source0:        %{name}-%{version}.tar.bz2

--- a/theme/SLE/wizard/cyan-black.qss
+++ b/theme/SLE/wizard/cyan-black.qss
@@ -18,7 +18,7 @@ YQWizard { background: black; }
 
 #DialogBanner {
   background-color: transparent;
-  font-family: Raleway, Sans-serif;
+  font-family: Poppins, Sans-serif;
   font: 24pt;
   margin-right: 20px;
 }
@@ -121,7 +121,7 @@ QListWidget {
 }
 
 #DialogHeadingLeft {
-  font-family: Raleway, Sans-serif;
+  font-family: Poppins, Sans-serif;
   font: 24pt;
   color: cyan;
   margin-top: 100%;
@@ -129,7 +129,7 @@ QListWidget {
   qproperty-alignment:AlignRight;
 }
 #DialogHeadingTop {
-  font-family: Raleway, Sans-serif;
+  font-family: Poppins, Sans-serif;
   font: 24pt;
   color: cyan;
 }

--- a/theme/SLE/wizard/highcontrast.qss
+++ b/theme/SLE/wizard/highcontrast.qss
@@ -19,7 +19,7 @@ YQMainWinDock { background: black; }
 
 #DialogBanner {
   background-color: transparent;
-  font-family: Raleway, Sans-serif;
+  font-family: Poppins, Sans-serif;
   font: 24pt;
   margin-right: 20px;
 }
@@ -122,7 +122,7 @@ QListWidget {
 }
 
 #DialogHeadingLeft {
-  font-family: Raleway, Sans-serif;
+  font-family: Poppins, Sans-serif;
   font: 24pt;
   color: #ffff00;
   margin-top: 100%;
@@ -130,7 +130,7 @@ QListWidget {
   qproperty-alignment:AlignRight;
 }
 #DialogHeadingTop {
-  font-family: Raleway, Sans-serif;
+  font-family: Poppins, Sans-serif;
   font: 24pt;
   color: #ffff00;
 }

--- a/theme/SLE/wizard/white-black.qss
+++ b/theme/SLE/wizard/white-black.qss
@@ -18,7 +18,7 @@ YQWizard { background: black; }
 
 #DialogBanner {
   background-color: transparent;
-  font-family: Raleway, Sans-serif;
+  font-family: Poppins, Sans-serif;
   font: 24pt;
   margin-right: 20px;
 }
@@ -121,7 +121,7 @@ QListWidget {
 }
 
 #DialogHeadingLeft {
-  font-family: Raleway, Sans-serif;
+  font-family: Poppins, Sans-serif;
   font: 24pt;
   color: white;
   margin-top: 100%;
@@ -129,7 +129,7 @@ QListWidget {
   qproperty-alignment:AlignRight;
 }
 #DialogHeadingTop {
-  font-family: Raleway, Sans-serif;
+  font-family: Poppins, Sans-serif;
   font: 24pt;
   color: white;
 }


### PR DESCRIPTION
### Problem

The package *yast2-theme* does not compile in IBS because missing fonts. It happens because style files were adapted to the new SLE brand, but high contrast styles are still using the old *Raleway* font. Such font is not included in installation images any longer. 

* https://github.com/yast/yast-theme/pull/132
* https://github.com/openSUSE/installation-images/pull/451


### Solution

Adapt all style files to use the Poppins fonts.
