### PR TITLE
Removing background-none definition to fix bsc#1183016

### DIFF
--- a/theme/SLE/wizard/installation.qss
+++ b/theme/SLE/wizard/installation.qss
@@ -66,6 +66,7 @@ YQRichText > YQTextBrowser {
 }
 
 QFrame { background-color: #2B2E38; color: #FFFFFF;}
+#wizard { background: #2B2E38; }
 
 QLabel, YQDialog {
   color: #FFFFFF;

--- a/theme/SLE/wizard/style.qss
+++ b/theme/SLE/wizard/style.qss
@@ -1,6 +1,3 @@
-QFrame { background-color: none; color: #FFFFFF;}
-#wizard { background: #2B2E38; }
-
 #steps
 {
   padding: 12px 1px 80px 12px;


### PR DESCRIPTION
Firstboot should be tested to ensure that this change does not break the background of the steps on the left.