### PR TITLE
Fix styles

### DIFF
--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar  5 11:12:32 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Fix styles in the running system (bsc#1183016).
+- Recover styles for the steps in firstboot.
+- 4.3.6
+
+-------------------------------------------------------------------
 Tue Mar  2 13:21:43 UTC 2021 - Kenneth Wimer <wimer@suse.com>
 
 - Fixes for bsc#1182497

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-theme
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 
 Source0:        %{name}-%{version}.tar.bz2

--- a/theme/SLE/wizard/installation.qss
+++ b/theme/SLE/wizard/installation.qss
@@ -66,6 +66,7 @@ YQRichText > YQTextBrowser {
 }
 
 QFrame { background-color: #2B2E38; color: #FFFFFF;}
+#wizard { background: #2B2E38; }
 
 QLabel, YQDialog {
   color: #FFFFFF;

--- a/theme/SLE/wizard/installation.qss
+++ b/theme/SLE/wizard/installation.qss
@@ -102,9 +102,9 @@ QTreeView, QTreeWidget {
   border-radius: 2px;
 }
 
-QTreeView::item:focus { 
-  color: #FFFFFF; 
-  border:none; 
+QTreeView::item:focus {
+  color: #FFFFFF;
+  border:none;
   outline: none;
   background-color: #404147;
 }
@@ -185,8 +185,8 @@ QToolButton#qt_calendar_nextmonth {
   qproperty-icon: url(inst_arr_right.png);
 }
 
-QCalendarWidget QAbstractItemView:enabled {  
- selection-background-color: #FFFFFF; 
+QCalendarWidget QAbstractItemView:enabled {
+ selection-background-color: #FFFFFF;
  selection-color: #000000;
  font-weight: bold;
 }
@@ -332,7 +332,7 @@ QTabBar::tear {
   border-radius: 1px;
 }
 
-QTabBar QToolButton { 
+QTabBar QToolButton {
     border: 1px solid #000000;
 }
 
@@ -441,7 +441,7 @@ QPushButton:default {
   border: 1px solid #30BA78;
   background-color: #30BA78;
   color: #FFFFFF;
-}			
+}
 QPushButton:disabled,
 QPushButton:default:disabled {
   color: rgba(255,255,255,60);
@@ -594,6 +594,11 @@ BusyBar {
 QToolTip {
   background-color: #ffECB5;
 }
+
+QSplitter {
+  background-color: #2B2E38;
+}
+
 QSplitter::handle {
   image: url(separator.png);
   height: 10px;
@@ -621,4 +626,51 @@ QComboBoxPrivateScroller
 {
   background-color: #2B2E38;
   color: #FFFFFF;
+}
+
+#steps
+{
+  padding: 12px 1px 80px 12px;
+  background: url(logo.svg) no-repeat bottom, #1f222b;
+}
+
+.steps_heading {
+  font-size: 16pt;
+  font-family: Poppins, Sans-serif;
+  background-color: #1f222b;
+  color: #fff;
+  padding: 0px 0px 12px 15px
+}
+
+.todo-step-name {
+  background-color: #1f222b;
+  padding: 6px 12px;
+  color: #fff;
+  font-size: 14px;
+}
+
+.done-step-name {
+  background-color: #1f222b;
+  padding: 6px 12px;
+  color: #fff;
+  font-size: 14px;
+}
+
+.current-step-name {
+  background-color: #30BA78;
+  padding: 6px 12px;
+  color: #fff;
+  font-size: 14px;
+}
+
+.todo-step-status {
+  background-color: #1f222b;
+}
+
+.done-step-status {
+  background-color: #1f222b;
+}
+
+.current-step-status {
+  background-color: #1f222b;
 }

--- a/theme/SLE/wizard/style.qss
+++ b/theme/SLE/wizard/style.qss
@@ -1,6 +1,3 @@
-QFrame { background-color: none; color: #FFFFFF;}
-#wizard { background: #2B2E38; }
-
 #steps
 {
   padding: 12px 1px 80px 12px;


### PR DESCRIPTION
### Problem

There are two issues introduced by https://github.com/yast/yast-theme/pull/137:

* Styles are broken in a running system https://bugzilla.suse.com/show_bug.cgi?id=1183016
* Styles for the steps in firstboot were removed. 


### Solution

Remove changes in *style.qss* and recover styles for the firstboot steps.

Note: This PR replaces https://github.com/yast/yast-theme/pull/140.


### Screenshots

* Broken styles in firstboot

![Screenshot from 2021-03-05 11-23-51](https://user-images.githubusercontent.com/1112304/110109549-85097f00-7da5-11eb-8629-1c74efff617e.png)


* Restored styles in firstboot

![Screenshot from 2021-03-05 11-20-31](https://user-images.githubusercontent.com/1112304/110109563-89359c80-7da5-11eb-848e-5acbd55a4730.png)
