### PR TITLE
Fix firstboot styles

### DIFF
--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar  8 14:13:19 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Improve styles for firstboot steps (related to bsc#1183162).
+- 4.3.7
+
+-------------------------------------------------------------------
 Fri Mar  5 11:12:32 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Fix styles in the running system (bsc#1183016).

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-theme
-Version:        4.3.6
+Version:        4.3.7
 Release:        0
 
 Source0:        %{name}-%{version}.tar.bz2

--- a/theme/SLE/wizard/installation.qss
+++ b/theme/SLE/wizard/installation.qss
@@ -65,7 +65,8 @@ YQRichText > YQTextBrowser {
   selection-color: #FFFFFF;
 }
 
-QFrame { background-color: #2B2E38; color: #FFFFFF;}
+QFrame { background-color: none; color: #FFFFFF; }
+YQPackageSelector { background-color: #2B2E38; }
 #wizard { background: #2B2E38; }
 
 QLabel, YQDialog {


### PR DESCRIPTION
### Problem

The styles for the steps in the firstboot looks with a wrong gray background color.

* Related to https://bugzilla.suse.com/show_bug.cgi?id=1183162.

![Screenshot from 2021-03-08 14-09-18](https://user-images.githubusercontent.com/1112304/110332163-e59ff280-8017-11eb-9aa0-4e096a741244.png)


### Solution

Do not force a *background-color* for all *QFrame* widgets. This was done so to avoid some issues with the background of the *YQPackageSelector*. Now, *YQPackageSelector* indicates its own background color without affecting the rest of *QFrame* widgets.

Kudos to @dgdavid and @shundhammer.

![Screenshot from 2021-03-08 13-57-05](https://user-images.githubusercontent.com/1112304/110332420-357eb980-8018-11eb-932b-b13f3aeb151f.png)
