### PR TITLE
Make title QToolButton backgrounds transparent

### DIFF
--- a/package/yast2-theme.changes
+++ b/package/yast2-theme.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 24 11:32:08 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Fix theme switcher background style
+  (related to bsc#1195730 and jsc#SLE-20564)
+- 4.4.6
+
+-------------------------------------------------------------------
 Wed Feb 23 15:11:37 UTC 2022 - David Diaz <dgonzalez@suse.com>
 
 - Add CSS rules for making visible the addons selector items

--- a/package/yast2-theme.spec
+++ b/package/yast2-theme.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-theme
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 
 Source0:        %{name}-%{version}.tar.bz2

--- a/theme/SLE/wizard/cyan-black.qss
+++ b/theme/SLE/wizard/cyan-black.qss
@@ -16,6 +16,10 @@ YQWizard { background: black; }
   background-color: #000;
 }
 
+#LogoHBox QToolButton {
+  background: transparent;
+}
+
 #DialogBanner {
   background-color: transparent;
   font-family: Poppins, Sans-serif;

--- a/theme/SLE/wizard/highcontrast.qss
+++ b/theme/SLE/wizard/highcontrast.qss
@@ -17,6 +17,10 @@ YQMainWinDock { background: black; }
   background-color: #000;
 }
 
+#LogoHBox QToolButton {
+  background: transparent;
+}
+
 #DialogBanner {
   background-color: transparent;
   font-family: Poppins, Sans-serif;

--- a/theme/SLE/wizard/installation.qss
+++ b/theme/SLE/wizard/installation.qss
@@ -17,6 +17,11 @@ YQMainWinDock { background: #2B2E38; }
   background-color: #1f222b;
   margin: 0px;
 }
+
+#LogoHBox QToolButton {
+  background: transparent;
+}
+
 #DialogBanner {
   background-color: transparent;
   font-family: Poppins, Sans-serif;

--- a/theme/SLE/wizard/white-black.qss
+++ b/theme/SLE/wizard/white-black.qss
@@ -16,6 +16,10 @@ YQWizard { background: black; }
   background-color: #000;
 }
 
+#LogoHBox QToolButton {
+  background: transparent;
+}
+
 #DialogBanner {
   background-color: transparent;
   font-family: Poppins, Sans-serif;


### PR DESCRIPTION
## Problem

The unstyled QToolButton holding the theme switcher is not honoring the transparent background used by the PNG file.

## Solution

Set the `#LogoHBox QToolButton` background to transparent.

## Screenshots

| Before | After |
|-|-|
| ![theme_switcher_before](https://user-images.githubusercontent.com/1691872/155493361-a869f8ae-a633-43a3-8c4f-0fb11656a7c1.png) | ![theme_switcher_after](https://user-images.githubusercontent.com/1691872/155493399-db7790f4-d019-41c1-a661-f04e6167e318.png) |

## Related links

* https://github.com/libyui/libyui/pull/65