### PR TITLE
Add a RichText CSS for the installation light theme

### DIFF
--- a/theme/SLE/wizard/installation-light_richtext.css
+++ b/theme/SLE/wizard/installation-light_richtext.css
@@ -1,0 +1,17 @@
+a { color: #2453ff; }
+a.dontlooklikealink { color: black; text-decoration: none; }
+.red { color: #DC3545; }
+.blue { color: #B3E8F6; }
+.green { color: #30BA78; }
+
+/* Styles for emulated checkbox labels in the addons selector screen  */
+/* See https://github.com/yast/yast-registration/pull/566 */
+.enabled-item {
+  color: black;
+  text-decoration: none;
+}
+
+.disabled-item {
+  color: gray;
+}
+/* end of styles for the addons selector */


### PR DESCRIPTION
Related to https://github.com/yast/yast-registration/pull/566 and https://github.com/yast/yast-theme/pull/155, this PR simply adds the _installation-light\_richtext.css_ file to make the addons selector _usable_ in a light theme.

| All items enabled | Some disabled items |
|-|-|
| ![Screenshot_sle15sp3_2022-02-24_10:53:05](https://user-images.githubusercontent.com/1691872/155511405-6850cabf-84d3-4414-b8aa-d0f6004199b8.png) | ![Screenshot_sle15sp3_2022-02-24_10:53:53](https://user-images.githubusercontent.com/1691872/155511427-a29c477b-9c9b-4fea-b132-1b9a74b003e3.png) |

 