### PR TITLE
Fix missusage of Sass rgba global function

### DIFF
--- a/theme/SLE/wizard/cyan-black.qss
+++ b/theme/SLE/wizard/cyan-black.qss
@@ -30,8 +30,8 @@ QPushButton:default {
 
 QPushButton:disabled,
 QPushButton:default:disabled {
-  color: white;
-  border: 1px solid white;
+  color: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 QPushButton:default:pressed,
@@ -360,8 +360,8 @@ QComboBox {
 }
 
 QComboBox::disabled {
-  color: white;
-  border-color: white;
+  color: rgba(255, 255, 255, 0.6);
+  border-color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 
@@ -434,7 +434,7 @@ QMenu::separator {
 }
 
 QMenu::item:disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* Calendar
@@ -451,7 +451,7 @@ QTimeEdit {
 
 QDateEdit::disabled,
 QTimeEdit::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 
@@ -515,7 +515,7 @@ QLineEdit:focus {
 }
 
 QLineEdit:disabled {
-  border-bottom: 1px solid white;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 QCheckBox,
@@ -526,7 +526,7 @@ YQCheckBoxFrame::indicator {
 }
 
 QCheckBox::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 QCheckBox:focus,
@@ -579,7 +579,7 @@ QRadioButton:focus {
 }
 
 QRadioButton::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 
@@ -810,7 +810,7 @@ YQWidgetCaption {
 }
 
 YQWidgetCaption::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 

--- a/theme/SLE/wizard/cyan-black.qss
+++ b/theme/SLE/wizard/cyan-black.qss
@@ -30,8 +30,8 @@ QPushButton:default {
 
 QPushButton:disabled,
 QPushButton:default:disabled {
-  color: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
+  border: 1px solid rgba(255, 255, 255, 60%);
 }
 
 QPushButton:default:pressed,
@@ -360,8 +360,8 @@ QComboBox {
 }
 
 QComboBox::disabled {
-  color: rgba(255, 255, 255, 0.6);
-  border-color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
+  border-color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 
@@ -434,7 +434,7 @@ QMenu::separator {
 }
 
 QMenu::item:disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 /* Calendar
@@ -451,7 +451,7 @@ QTimeEdit {
 
 QDateEdit::disabled,
 QTimeEdit::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 
@@ -515,7 +515,7 @@ QLineEdit:focus {
 }
 
 QLineEdit:disabled {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+  border-bottom: 1px solid rgba(255, 255, 255, 60%);
 }
 
 QCheckBox,
@@ -526,7 +526,7 @@ YQCheckBoxFrame::indicator {
 }
 
 QCheckBox::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 QCheckBox:focus,
@@ -579,7 +579,7 @@ QRadioButton:focus {
 }
 
 QRadioButton::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 
@@ -810,7 +810,7 @@ YQWidgetCaption {
 }
 
 YQWidgetCaption::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 

--- a/theme/SLE/wizard/cyan-black_richtext.css
+++ b/theme/SLE/wizard/cyan-black_richtext.css
@@ -27,7 +27,7 @@ a {
 }
 
 .disabled-item {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 /* end of styles for the addons selector */

--- a/theme/SLE/wizard/cyan-black_richtext.css
+++ b/theme/SLE/wizard/cyan-black_richtext.css
@@ -27,7 +27,7 @@ a {
 }
 
 .disabled-item {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* end of styles for the addons selector */

--- a/theme/SLE/wizard/highcontrast.qss
+++ b/theme/SLE/wizard/highcontrast.qss
@@ -30,8 +30,8 @@ QPushButton:default {
 
 QPushButton:disabled,
 QPushButton:default:disabled {
-  color: white;
-  border: 1px solid white;
+  color: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 QPushButton:default:pressed,
@@ -360,8 +360,8 @@ QComboBox {
 }
 
 QComboBox::disabled {
-  color: white;
-  border-color: white;
+  color: rgba(255, 255, 255, 0.6);
+  border-color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 
@@ -434,7 +434,7 @@ QMenu::separator {
 }
 
 QMenu::item:disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* Calendar
@@ -451,7 +451,7 @@ QTimeEdit {
 
 QDateEdit::disabled,
 QTimeEdit::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 
@@ -515,7 +515,7 @@ QLineEdit:focus {
 }
 
 QLineEdit:disabled {
-  border-bottom: 1px solid white;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 QCheckBox,
@@ -526,7 +526,7 @@ YQCheckBoxFrame::indicator {
 }
 
 QCheckBox::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 QCheckBox:focus,
@@ -579,7 +579,7 @@ QRadioButton:focus {
 }
 
 QRadioButton::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 
@@ -810,7 +810,7 @@ YQWidgetCaption {
 }
 
 YQWidgetCaption::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 

--- a/theme/SLE/wizard/highcontrast.qss
+++ b/theme/SLE/wizard/highcontrast.qss
@@ -30,8 +30,8 @@ QPushButton:default {
 
 QPushButton:disabled,
 QPushButton:default:disabled {
-  color: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
+  border: 1px solid rgba(255, 255, 255, 60%);
 }
 
 QPushButton:default:pressed,
@@ -360,8 +360,8 @@ QComboBox {
 }
 
 QComboBox::disabled {
-  color: rgba(255, 255, 255, 0.6);
-  border-color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
+  border-color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 
@@ -434,7 +434,7 @@ QMenu::separator {
 }
 
 QMenu::item:disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 /* Calendar
@@ -451,7 +451,7 @@ QTimeEdit {
 
 QDateEdit::disabled,
 QTimeEdit::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 
@@ -515,7 +515,7 @@ QLineEdit:focus {
 }
 
 QLineEdit:disabled {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+  border-bottom: 1px solid rgba(255, 255, 255, 60%);
 }
 
 QCheckBox,
@@ -526,7 +526,7 @@ YQCheckBoxFrame::indicator {
 }
 
 QCheckBox::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 QCheckBox:focus,
@@ -579,7 +579,7 @@ QRadioButton:focus {
 }
 
 QRadioButton::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 
@@ -810,7 +810,7 @@ YQWidgetCaption {
 }
 
 YQWidgetCaption::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 

--- a/theme/SLE/wizard/highcontrast_richtext.css
+++ b/theme/SLE/wizard/highcontrast_richtext.css
@@ -27,7 +27,7 @@ a {
 }
 
 .disabled-item {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 /* end of styles for the addons selector */

--- a/theme/SLE/wizard/highcontrast_richtext.css
+++ b/theme/SLE/wizard/highcontrast_richtext.css
@@ -27,7 +27,7 @@ a {
 }
 
 .disabled-item {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* end of styles for the addons selector */

--- a/theme/SLE/wizard/installation.qss
+++ b/theme/SLE/wizard/installation.qss
@@ -30,8 +30,8 @@ QPushButton:default {
 
 QPushButton:disabled,
 QPushButton:default:disabled {
-  color: white;
-  border: 1px solid white;
+  color: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 QPushButton:default:pressed,
@@ -360,8 +360,8 @@ QComboBox {
 }
 
 QComboBox::disabled {
-  color: white;
-  border-color: white;
+  color: rgba(255, 255, 255, 0.6);
+  border-color: rgba(255, 255, 255, 0.6);
   background-color: #2b2e38;
 }
 
@@ -434,7 +434,7 @@ QMenu::separator {
 }
 
 QMenu::item:disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* Calendar
@@ -451,7 +451,7 @@ QTimeEdit {
 
 QDateEdit::disabled,
 QTimeEdit::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #2b2e38;
 }
 
@@ -515,7 +515,7 @@ QLineEdit:focus {
 }
 
 QLineEdit:disabled {
-  border-bottom: 1px solid white;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 QCheckBox,
@@ -526,7 +526,7 @@ YQCheckBoxFrame::indicator {
 }
 
 QCheckBox::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 QCheckBox:focus,
@@ -579,7 +579,7 @@ QRadioButton:focus {
 }
 
 QRadioButton::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #2b2e38;
 }
 
@@ -810,7 +810,7 @@ YQWidgetCaption {
 }
 
 YQWidgetCaption::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #2b2e38;
 }
 

--- a/theme/SLE/wizard/installation.qss
+++ b/theme/SLE/wizard/installation.qss
@@ -30,8 +30,8 @@ QPushButton:default {
 
 QPushButton:disabled,
 QPushButton:default:disabled {
-  color: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
+  border: 1px solid rgba(255, 255, 255, 60%);
 }
 
 QPushButton:default:pressed,
@@ -360,8 +360,8 @@ QComboBox {
 }
 
 QComboBox::disabled {
-  color: rgba(255, 255, 255, 0.6);
-  border-color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
+  border-color: rgba(255, 255, 255, 60%);
   background-color: #2b2e38;
 }
 
@@ -434,7 +434,7 @@ QMenu::separator {
 }
 
 QMenu::item:disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 /* Calendar
@@ -451,7 +451,7 @@ QTimeEdit {
 
 QDateEdit::disabled,
 QTimeEdit::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #2b2e38;
 }
 
@@ -515,7 +515,7 @@ QLineEdit:focus {
 }
 
 QLineEdit:disabled {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+  border-bottom: 1px solid rgba(255, 255, 255, 60%);
 }
 
 QCheckBox,
@@ -526,7 +526,7 @@ YQCheckBoxFrame::indicator {
 }
 
 QCheckBox::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 QCheckBox:focus,
@@ -579,7 +579,7 @@ QRadioButton:focus {
 }
 
 QRadioButton::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #2b2e38;
 }
 
@@ -810,7 +810,7 @@ YQWidgetCaption {
 }
 
 YQWidgetCaption::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #2b2e38;
 }
 

--- a/theme/SLE/wizard/installation_richtext.css
+++ b/theme/SLE/wizard/installation_richtext.css
@@ -27,7 +27,7 @@ a {
 }
 
 .disabled-item {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 /* end of styles for the addons selector */

--- a/theme/SLE/wizard/installation_richtext.css
+++ b/theme/SLE/wizard/installation_richtext.css
@@ -27,7 +27,7 @@ a {
 }
 
 .disabled-item {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* end of styles for the addons selector */

--- a/theme/SLE/wizard/white-black.qss
+++ b/theme/SLE/wizard/white-black.qss
@@ -30,8 +30,8 @@ QPushButton:default {
 
 QPushButton:disabled,
 QPushButton:default:disabled {
-  color: white;
-  border: 1px solid white;
+  color: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 QPushButton:default:pressed,
@@ -360,8 +360,8 @@ QComboBox {
 }
 
 QComboBox::disabled {
-  color: white;
-  border-color: white;
+  color: rgba(255, 255, 255, 0.6);
+  border-color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 
@@ -434,7 +434,7 @@ QMenu::separator {
 }
 
 QMenu::item:disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* Calendar
@@ -451,7 +451,7 @@ QTimeEdit {
 
 QDateEdit::disabled,
 QTimeEdit::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 
@@ -515,7 +515,7 @@ QLineEdit:focus {
 }
 
 QLineEdit:disabled {
-  border-bottom: 1px solid white;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 QCheckBox,
@@ -526,7 +526,7 @@ YQCheckBoxFrame::indicator {
 }
 
 QCheckBox::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 QCheckBox:focus,
@@ -579,7 +579,7 @@ QRadioButton:focus {
 }
 
 QRadioButton::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 
@@ -810,7 +810,7 @@ YQWidgetCaption {
 }
 
 YQWidgetCaption::disabled {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   background-color: #000000;
 }
 

--- a/theme/SLE/wizard/white-black.qss
+++ b/theme/SLE/wizard/white-black.qss
@@ -30,8 +30,8 @@ QPushButton:default {
 
 QPushButton:disabled,
 QPushButton:default:disabled {
-  color: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
+  border: 1px solid rgba(255, 255, 255, 60%);
 }
 
 QPushButton:default:pressed,
@@ -360,8 +360,8 @@ QComboBox {
 }
 
 QComboBox::disabled {
-  color: rgba(255, 255, 255, 0.6);
-  border-color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
+  border-color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 
@@ -434,7 +434,7 @@ QMenu::separator {
 }
 
 QMenu::item:disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 /* Calendar
@@ -451,7 +451,7 @@ QTimeEdit {
 
 QDateEdit::disabled,
 QTimeEdit::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 
@@ -515,7 +515,7 @@ QLineEdit:focus {
 }
 
 QLineEdit:disabled {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+  border-bottom: 1px solid rgba(255, 255, 255, 60%);
 }
 
 QCheckBox,
@@ -526,7 +526,7 @@ YQCheckBoxFrame::indicator {
 }
 
 QCheckBox::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 QCheckBox:focus,
@@ -579,7 +579,7 @@ QRadioButton:focus {
 }
 
 QRadioButton::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 
@@ -810,7 +810,7 @@ YQWidgetCaption {
 }
 
 YQWidgetCaption::disabled {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
   background-color: #000000;
 }
 

--- a/theme/SLE/wizard/white-black_richtext.css
+++ b/theme/SLE/wizard/white-black_richtext.css
@@ -27,7 +27,7 @@ a {
 }
 
 .disabled-item {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 60%);
 }
 
 /* end of styles for the addons selector */

--- a/theme/SLE/wizard/white-black_richtext.css
+++ b/theme/SLE/wizard/white-black_richtext.css
@@ -27,7 +27,7 @@ a {
 }
 
 .disabled-item {
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* end of styles for the addons selector */

--- a/theme/assets/scss/theme-vars/cyan-black.scss
+++ b/theme/assets/scss/theme-vars/cyan-black.scss
@@ -16,8 +16,8 @@ $yast-dark-grey-500: #2b2e38;
 $yast-dark-grey-700: #757575;
 $yast-bg-900: #1f222b;
 
-// rgba
-$yast-disabled: rgba(255, 255, 255, 60%);
+// rgba (as an interpolated string for not processing it with Sass and letting Qt makes the work)
+$yast-disabled: #{"rgba(255, 255, 255, 60%)"};
 
 // borders
 $yast-border: $yast-black;

--- a/theme/assets/scss/theme-vars/cyan-black.scss
+++ b/theme/assets/scss/theme-vars/cyan-black.scss
@@ -17,7 +17,7 @@ $yast-dark-grey-700: #757575;
 $yast-bg-900: #1f222b;
 
 // rgba
-$yast-disabled: rgba(255, 255, 255, 60);
+$yast-disabled: rgba(255, 255, 255, 60%);
 
 // borders
 $yast-border: $yast-black;

--- a/theme/assets/scss/theme-vars/dark.scss
+++ b/theme/assets/scss/theme-vars/dark.scss
@@ -15,8 +15,8 @@ $yast-dark-grey-500: #2b2e38;
 $yast-dark-grey-700: #757575;
 $yast-bg-900: #1f222b;
 
-// rgba
-$yast-disabled: rgba(255, 255, 255, 60%);
+// rgba (as an interpolated string for not processing it with Sass and letting Qt makes the work)
+$yast-disabled: #{"rgba(255, 255, 255, 60%)"};
 
 // borders
 $yast-border: $yast-black;

--- a/theme/assets/scss/theme-vars/dark.scss
+++ b/theme/assets/scss/theme-vars/dark.scss
@@ -16,7 +16,7 @@ $yast-dark-grey-700: #757575;
 $yast-bg-900: #1f222b;
 
 // rgba
-$yast-disabled: rgba(255, 255, 255, 60);
+$yast-disabled: rgba(255, 255, 255, 60%);
 
 // borders
 $yast-border: $yast-black;

--- a/theme/assets/scss/theme-vars/highcontrast.scss
+++ b/theme/assets/scss/theme-vars/highcontrast.scss
@@ -19,7 +19,7 @@ $yast-dark-grey-700: #757575;
 $yast-bg-900: #1f222b;
 
 // rgba
-$yast-disabled: rgba(255, 255, 255, 60);
+$yast-disabled: rgba(255, 255, 255, 60%);
 
 // borders
 $yast-border: $yast-black;

--- a/theme/assets/scss/theme-vars/highcontrast.scss
+++ b/theme/assets/scss/theme-vars/highcontrast.scss
@@ -18,8 +18,8 @@ $yast-dark-grey-500: #2b2e38;
 $yast-dark-grey-700: #757575;
 $yast-bg-900: #1f222b;
 
-// rgba
-$yast-disabled: rgba(255, 255, 255, 60%);
+// rgba (as an interpolated string for not processing it with Sass and letting Qt makes the work)
+$yast-disabled: #{"rgba(255, 255, 255, 60%)"};
 
 // borders
 $yast-border: $yast-black;

--- a/theme/assets/scss/theme-vars/light.scss
+++ b/theme/assets/scss/theme-vars/light.scss
@@ -22,7 +22,6 @@ $yast-dark-grey-500: #2b2e38;
 $yast-dark-grey-700: #757575;
 $yast-bg-900: #0e7e3c;
 
-// rgba
 $yast-disabled: #B6B4B4;
 
 // borders

--- a/theme/assets/scss/theme-vars/white-black.scss
+++ b/theme/assets/scss/theme-vars/white-black.scss
@@ -15,8 +15,8 @@ $yast-dark-grey-500: #2b2e38;
 $yast-dark-grey-700: #757575;
 $yast-bg-900: #1f222b;
 
-// rgba
-$yast-disabled: rgba(255, 255, 255, 60%);
+// rgba (as an interpolated string for not processing it with Sass and letting Qt makes the work)
+$yast-disabled: #{"rgba(255, 255, 255, 60%)"};
 
 // borders
 $yast-border: $yast-black;

--- a/theme/assets/scss/theme-vars/white-black.scss
+++ b/theme/assets/scss/theme-vars/white-black.scss
@@ -16,7 +16,7 @@ $yast-dark-grey-700: #757575;
 $yast-bg-900: #1f222b;
 
 // rgba
-$yast-disabled: rgba(255, 255, 255, 60);
+$yast-disabled: rgba(255, 255, 255, 60%);
 
 // borders
 $yast-border: $yast-black;


### PR DESCRIPTION
The value used for the alpha channel in the [global _rgba_ Sass function](https://sass-lang.com/documentation/modules#rgb) is wrong, which ends up producing the rgb color instead.

According to the documentation

> The alpha channel can be specified as either a unitless number between
> 0 and 1 (inclusive), or a percentage between 0% and 100% (inclusive)

~~To fix it, we can either: add the missing `%` or change the value to its equivalent unitless number between 0 and 1. The first option was chosen.~~

But using a good value does not work either because it produces a CSS _rgba_ function with a unitless alpha value. I.e., both `rgba(255, 255, 255, 0.6)` and `rgba(255, 255, 255, 60%)` **Sass** built-in functions produce `rgba(255, 255, 255, 0.6)` **CSS** function.

However, as @lslezak mentioned in IRC channel, [Qt](https://doc.qt.io/qt-5/stylesheet-reference.html) expect a percentage between 0 and 100 for the alpha channel value in the _rgba_ function. A complete mess :man_shrugging:

So, the (poor man) solution is to interpolate the full _rgba_ function to produce the value expected for Qt. Maybe we could [create a Sass user function](https://github.com/sass/libsass/issues/151#issuecomment-33536506) to do so, but for now it is enough as it is.

## Tests (updated with the latest fix)

Tested manually in the first screen of the installer, which holds a disabled `Back` _QPushButton_.

It works.

## Screenshots (updated with the latest fix)

| Name |  Screenshot |
|-|-|
| Dark |![dark](https://user-images.githubusercontent.com/1691872/155558074-b10df28b-0ad2-4087-be45-08ad173e937a.png) |
| Light | ![light](https://user-images.githubusercontent.com/1691872/155558070-19e52b6e-a927-4c65-b1ab-94b2f070e0bc.png)|
| Cyan - Black | ![cyan](https://user-images.githubusercontent.com/1691872/155558072-da7e9c7c-0e5f-42e4-8109-9433bbebbe6f.png) |
| White - Black | ![bw](https://user-images.githubusercontent.com/1691872/155558058-d4a20c29-6413-456a-8960-4d2a40bced26.png) |
| High contrast | ![highcontrast png](https://user-images.githubusercontent.com/1691872/155558067-f9531b19-4562-49d7-8706-606e6282bb59.png) |










